### PR TITLE
ci: build pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
The following branch protection rules are required for this change not to be risky:

![Screenshot 2024-09-07 11 09 27 PM](https://github.com/user-attachments/assets/307780f6-e8e9-4427-ab11-18421675148e)