### PR TITLE
fix: disable ship collision rotation

### DIFF
--- a/src/app.simulation.spec.ts
+++ b/src/app.simulation.spec.ts
@@ -51,7 +51,7 @@ describe("Game", () => {
   beforeEach(() => {
     game = new Game(config);
     frameIndex = 0;
-    step();
+    stepFramesBy(1);
   });
 
   describe(Ship.name, () => {
@@ -64,7 +64,7 @@ describe("Game", () => {
       // collide the player into the enemy
       for (let frame = 1; frame <= 120; frame++) {
         player.moveRight();
-        step();
+        stepFramesBy(1);
 
         expect(player.getBody().angle).toEqual(0);
         expect(enemy.getBody().angle).toEqual(0);
@@ -81,11 +81,11 @@ describe("Game", () => {
       // move the player right at 5ppf for 25 frames
       for (let n = 1; n <= 25; n++) {
         player.moveRight();
-        step();
+        stepFramesBy(1);
       }
 
       player.stopMoving();
-      step();
+      stepFramesBy(1);
 
       // the player should now be roughly located at 225,400
       expect(player.x).toBeCloseTo(225);
@@ -94,11 +94,11 @@ describe("Game", () => {
       // move the player up at 5ppf for 10 frames
       for (let n = 1; n <= 10; n++) {
         player.moveUp();
-        step();
+        stepFramesBy(1);
       }
 
       player.stopMoving();
-      step();
+      stepFramesBy(1);
 
       // the player should now be roughly located at 225,350
       expect(player.x).toBeCloseTo(225);
@@ -108,11 +108,11 @@ describe("Game", () => {
       for (let n = 1; n <= 10; n++) {
         player.moveDown();
         player.moveLeft();
-        step();
+        stepFramesBy(1);
       }
 
       player.stopMoving();
-      step();
+      stepFramesBy(1);
 
       // the player should now be roughly located at 175,400
       expect(player.x).toBeCloseTo(175);
@@ -124,13 +124,13 @@ describe("Game", () => {
 
       // have the player face left
       player.faceLeft();
-      step();
+      stepFramesBy(1);
       expect(player.angle).toEqual(-180);
       expect(player.isFacingLeft).toBeTruthy();
 
       // have the player face right
       player.faceRight();
-      step();
+      stepFramesBy(1);
       expect(player.angle).toEqual(0);
       expect(player.isFacingLeft).toBeFalsy();
     });
@@ -147,11 +147,11 @@ describe("Game", () => {
       // fire the player's primary weapon at 10ppf
       player.firePrimaryWeapon();
 
-      step(50);
+      stepFramesBy(50);
       // the laser should be roughly 600,400: no collision
       expect(enemy.active).toBeTruthy();
 
-      step(10);
+      stepFramesBy(10);
       // the laser should be roughly 700,400: collision with enemy
       expect(enemy.active).toBeFalsy();
       expect(enemy.body).toBeUndefined();
@@ -166,7 +166,7 @@ describe("Game", () => {
       // simulate 5 seconds worth of idle state
       for (let frame = 1; frame <= FPS * 5; frame++) {
         enemy.idle();
-        step();
+        stepFramesBy(1);
 
         // tolerance + (speed * max_idle_delay_frames)
         const precision = 3 + 0.25 * 10;
@@ -181,7 +181,7 @@ describe("Game", () => {
       expect(enemy.active).toBeTruthy();
 
       enemy.destroy();
-      step();
+      stepFramesBy(1);
       // update must handle destruction gracefully
       enemy.update(MS_PER_FRAME, MS_PER_FRAME);
 
@@ -192,7 +192,7 @@ describe("Game", () => {
       expect(player.active).toBeTruthy();
 
       player.destroy();
-      step();
+      stepFramesBy(1);
       // update must handle destruction gracefully
       player.update(MS_PER_FRAME, MS_PER_FRAME);
 
@@ -220,28 +220,28 @@ describe("Game", () => {
       resetPlayerInput(playerInput);
       playerInput["right"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.x).toBeCloseTo(205, 1);
       expect(myPlayer.y).toBe(200);
 
       resetPlayerInput(playerInput);
       playerInput["left"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.x).toBeCloseTo(200, 1);
       expect(myPlayer.y).toBe(200);
 
       resetPlayerInput(playerInput);
       playerInput["up"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.x).toBeCloseTo(200, 1);
       expect(myPlayer.y).toBeCloseTo(195, 1);
 
       resetPlayerInput(playerInput);
       playerInput["down"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.x).toBeCloseTo(200, 1);
       expect(myPlayer.y).toBeCloseTo(200, 1);
 
@@ -249,7 +249,7 @@ describe("Game", () => {
       playerInput["up"].isDown = true;
       playerInput["right"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.x).toBeCloseTo(205, 1);
       expect(myPlayer.y).toBeCloseTo(195, 1);
 
@@ -257,27 +257,27 @@ describe("Game", () => {
       playerInput["left"].isDown = true;
       playerInput["down"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.x).toBeCloseTo(200, 1);
       expect(myPlayer.y).toBeCloseTo(200, 1);
 
       resetPlayerInput(playerInput);
       playerInput["face-left"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.isFacingLeft).toBeTruthy();
 
       resetPlayerInput(playerInput);
       playerInput["face-right"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(myPlayer.isFacingLeft).toBeFalsy();
 
       expect(getActiveLaserAmmo(scene)).toHaveLength(0);
       resetPlayerInput(playerInput);
       playerInput["fire-primary"].isDown = true;
       myPlayer.update(MS_PER_FRAME, MS_PER_FRAME);
-      step();
+      stepFramesBy(1);
       expect(getActiveLaserAmmo(scene)).toHaveLength(1);
     });
   });
@@ -298,7 +298,7 @@ function getActiveLaserAmmo(scene: Scene) {
     );
 }
 
-function step(count = 1) {
+function stepFramesBy(count: number) {
   for (let n = 0; n < count; n++) {
     game.headlessStep(++frameIndex * MS_PER_FRAME, MS_PER_FRAME);
   }

--- a/src/app.simulation.spec.ts
+++ b/src/app.simulation.spec.ts
@@ -55,14 +55,14 @@ describe("Game", () => {
 
   describe(Ship.name, () => {
     it("should not rotate on collision", () => {
-      // if the player is moving right at 5ppf, they'll collide in 120 frames
-      expect(player.x).toEqual(100);
-      expect(enemy.x).toEqual(700);
-      expect(player.getSpeed()).toEqual(5);
+      // position the player above the enemy, with some horizontal overlap
+      player.setPosition(680, 350);
+      enemy.setPosition(700, 400);
+      player.setSpeed(5);
 
       // collide the player into the enemy
-      for (let frame = 1; frame <= 120; frame++) {
-        player.moveRight();
+      for (let frame = 1; frame <= 10; frame++) {
+        player.moveDown();
         stepFramesBy(1);
 
         expect(player.getBody().angle).toEqual(0);

--- a/src/app.simulation.spec.ts
+++ b/src/app.simulation.spec.ts
@@ -47,10 +47,29 @@ jest.spyOn(console, "log").mockImplementation(() => {});
 describe("Game", () => {
   describe(Ship.name, () => {
     it("should not rotate on collision", () => {
-      new Game(config);
+      const game = new Game(config);
 
-      expect(player.getBody().inertia).toBe(Infinity);
-      expect(enemy.getBody().inertia).toBe(Infinity);
+      // if the player is moving right at 5ppf, they'll collide in 120 frames
+      expect(player.x).toEqual(100);
+      expect(enemy.x).toEqual(700);
+      expect(player.getSpeed()).toEqual(5);
+
+      let playerRotation = player.getBody().angle;
+      let enemyRotation = enemy.getBody().angle;
+
+      // collide the player into the enemy
+      for (let frame = 1; frame <= 120; frame++) {
+        player.moveRight();
+        game.headlessStep(frame * MS_PER_FRAME, MS_PER_FRAME);
+        player.update(frame * MS_PER_FRAME, MS_PER_FRAME);
+        enemy.update(frame * MS_PER_FRAME, MS_PER_FRAME);
+
+        playerRotation += Math.abs(player.getBody().angle);
+        enemyRotation += Math.abs(enemy.getBody().angle);
+      }
+
+      expect(playerRotation).toEqual(0);
+      expect(enemyRotation).toEqual(0);
     });
   });
 

--- a/src/app.simulation.spec.ts
+++ b/src/app.simulation.spec.ts
@@ -6,6 +6,7 @@ import { Player, PlayerInput } from "./game-objects/Player";
 import { Ship } from "./game-objects/Ship";
 
 window.focus = jest.fn();
+jest.spyOn(console, "log").mockImplementation(() => {});
 
 const FPS = 60;
 const MS_PER_FRAME = 1000 / FPS;
@@ -44,8 +45,6 @@ function update(time: number, delta: number) {
   player.update(time, delta);
   enemy.update(time, delta);
 }
-
-jest.spyOn(console, "log").mockImplementation(() => {});
 
 describe("Game", () => {
   beforeEach(() => {

--- a/src/app.simulation.spec.ts
+++ b/src/app.simulation.spec.ts
@@ -1,8 +1,9 @@
 import "@geckos.io/phaser-on-nodejs";
-import { describe, expect, jest, test } from "@jest/globals";
+import { describe, expect, it, jest, test } from "@jest/globals";
 import { Game, Scene } from "phaser";
 import { Enemy } from "./game-objects/Enemy";
 import { Player, PlayerInput } from "./game-objects/Player";
+import { Ship } from "./game-objects/Ship";
 
 window.focus = jest.fn();
 
@@ -43,8 +44,17 @@ function create(this: Scene) {
 jest.useFakeTimers();
 jest.spyOn(console, "log").mockImplementation(() => {});
 
-describe(Player.name, () => {
-  describe("Integration", () => {
+describe("Game", () => {
+  describe(Ship.name, () => {
+    it("should not rotate on collision", () => {
+      new Game(config);
+
+      expect(player.getBody().inertia).toBe(Infinity);
+      expect(enemy.getBody().inertia).toBe(Infinity);
+    });
+  });
+
+  describe("Simulation", () => {
     test(
       "Movement and Position",
       async () => {

--- a/src/game-objects/Enemy.ts
+++ b/src/game-objects/Enemy.ts
@@ -3,7 +3,7 @@ import { LaserWeaponSystem } from "../weapons/LaserWeaponSystem";
 import { Ship } from "./Ship";
 
 export class Enemy extends Ship {
-  private updateState: "idle" | "engage" = "idle";
+  private updateState: "disabled" | "idle" | "engage" = "disabled";
   private updateTime = 0;
   private updateDelay = 0;
 
@@ -25,6 +25,10 @@ export class Enemy extends Ship {
     this.setFillStyle(Phaser.Display.Color.GetColor(200, 110, 110));
 
     this.attachPrimaryWeapon(new LaserWeaponSystem(this.scene));
+  }
+
+  idle() {
+    this.updateState = "idle";
   }
 
   update(time: number, _delta: number): void {

--- a/src/game-objects/Ship.ts
+++ b/src/game-objects/Ship.ts
@@ -1,3 +1,4 @@
+import { BodyType } from "matter";
 import { GameObjects, Scene } from "phaser";
 import { EmptyWeaponSystem } from "../weapons/EmptyWeaponSystem";
 import { Weapon } from "../weapons/Weapon";
@@ -15,9 +16,14 @@ export abstract class Ship extends GameObjects.Polygon {
     super(scene, x, y, vertices);
     this.scene.add.existing(this);
     this.scene.matter.add.gameObject(this);
+    this.scene.matter.body.setInertia(this.getBody(), Infinity);
   }
 
   abstract update(time: number, delta: number): void;
+
+  getBody() {
+    return this.body as BodyType;
+  }
 
   getSpeed() {
     return this.speed;

--- a/src/scenes/MainScene.ts
+++ b/src/scenes/MainScene.ts
@@ -48,6 +48,7 @@ export class MainScene extends Scene {
     this.player = new Player(this, 100, 400, playerInput);
 
     this.enemy = new Enemy(this, 700, 400);
+    this.enemy.idle();
     this.enemy.faceLeft();
 
     this.fpsText = this.add.text(16, 32, "", {


### PR DESCRIPTION
Also replaced the use of Jest's fake timers with a more appropriate call to Phaser's headless step method.